### PR TITLE
commented Anime 4K Upscaler code due to malfunction.

### DIFF
--- a/include/playerwindows.h
+++ b/include/playerwindows.h
@@ -78,7 +78,7 @@ namespace playerWindows{
 	void RightTrackVideoWindow(bool *focus, bool *first_item);
 	void RightTrackAudioWindow(bool *focus, bool *first_item);
 	void RightTrackSubWindow(bool *focus, bool *first_item);
-	void RightHomeAnime4K(bool *focus, bool *first_item);
+	//void RightHomeAnime4K(bool *focus, bool *first_item);
 	void RightHomeARatio(bool *focus, bool *first_item);
 	void RightHomeCustomARatio(bool *focus, bool *first_item);
 	void RightHomeImage(bool *focus, bool *first_item);

--- a/source/UI/playerWindows.cpp
+++ b/source/UI/playerWindows.cpp
@@ -51,7 +51,7 @@ namespace playerWindows{
 		rightmenuposX = item.rightmenu_startpos;
 		if(item.rightmenu_startpos>1080)item.rightmenu_startpos-=10;
 		playerWindows::SetupRightWindow();
-		std::vector<std::string> topmenu  = {"Tracks","Chapters","Aspect Ratio","Image","Audio","Subtitle","ShaderMania","Anime4K v4.0.1"};
+		std::vector<std::string> topmenu  = {"Tracks","Chapters","Aspect Ratio","Image","Audio","Subtitle","ShaderMania"};
 		if (ImGui::Begin("Right Menu Home", nullptr, ImGuiWindowFlags_NoTitleBar|ImGuiWindowFlags_NoResize|ImGuiWindowFlags_NoMove|ImGuiWindowFlags_NoScrollbar)) {
 			ImGui::SetNextWindowFocus();
 			if (ImGui::BeginListBox("Right Menu Home List",ImVec2(1280.0f, 720.0f))){
@@ -79,9 +79,9 @@ namespace playerWindows{
 						if(topmenu[n] == "ShaderMania"){
 							item.rightmenustate = PLAYER_RIGHT_MENU_SHADERMANIA;
 						}
-						if(topmenu[n] == "Anime4K v4.0.1"){
+						/*if(topmenu[n] == "Anime4K v4.0.1"){
 							item.rightmenustate = PLAYER_RIGHT_MENU_ANIME4K;
-						}
+						}*/
 					}
 				}
 				if (*first_item) {
@@ -258,7 +258,7 @@ namespace playerWindows{
 	
 	//Used For 1080p screens with less powerful GPUs:
 	//https://github.com/bloc97/Anime4K/blob/815b122284304e6e1e244a8cf6a160eeaa07040c/GLSL_Instructions.md
-		void RightHomeAnime4K(bool *focus, bool *first_item){
+	/*	void RightHomeAnime4K(bool *focus, bool *first_item){
 		playerWindows::SetupRightWindow();
 		std::vector<std::string> topmenu  = {"Mode A (Fast)","Mode B (Fast)","Mode C (Fast)","Mode A+A (Fast)","Mode B+B (Fast)","Mode C+A (Fast)","Show Info","Disabled"};
 		if (ImGui::Begin("Right Menu ARatio", nullptr, ImGuiWindowFlags_NoTitleBar|ImGuiWindowFlags_NoResize|ImGuiWindowFlags_NoMove|ImGuiWindowFlags_NoScrollbar)) {
@@ -322,7 +322,7 @@ namespace playerWindows{
 			}
 		}
 		playerWindows::ExitWindow();
-	}
+	}*/
 
 	void RightHomeARatio(bool *focus, bool *first_item){
 		playerWindows::SetupRightWindow();

--- a/source/gui.cpp
+++ b/source/gui.cpp
@@ -590,9 +590,9 @@ namespace GUI {
 							else if(item.rightmenustate == PLAYER_RIGHT_MENU_CHAPTERS){
 								item.rightmenustate = PLAYER_RIGHT_MENU_HOME;
 							}
-							else if(item.rightmenustate == PLAYER_RIGHT_MENU_ANIME4K){
+							/*else if(item.rightmenustate == PLAYER_RIGHT_MENU_ANIME4K){
 								item.rightmenustate = PLAYER_RIGHT_MENU_HOME;
-							}
+							}*/
 							else if(item.rightmenustate == PLAYER_RIGHT_MENU_ARATIO){
 								item.rightmenustate = PLAYER_RIGHT_MENU_HOME;
 							}
@@ -899,9 +899,9 @@ namespace GUI {
 				case PLAYER_RIGHT_MENU_CHAPTERS:
 					playerWindows::RightChapterWindow(&item.rightmenu_focus,&item.rightmenu_first_item);
 					break;
-				case PLAYER_RIGHT_MENU_ANIME4K:
+				/*case PLAYER_RIGHT_MENU_ANIME4K:
 					playerWindows::RightHomeAnime4K(&item.rightmenu_focus,&item.rightmenu_first_item);
-					break;	
+					break;*/
 				case PLAYER_RIGHT_MENU_ARATIO:
 					playerWindows::RightHomeARatio(&item.rightmenu_focus,&item.rightmenu_first_item);
 					break;


### PR DESCRIPTION
Anime4k uses the native resolution of the screen running mpv to scale, in our case mpv runs at 720p, upscaling nothing, just consuming processor.
I have not deleted it, I just left it commented in case I replace the script with another Upscaler in the future.