### PR TITLE
Fix Save Color in .ini

### DIFF
--- a/source/UI/apppopups.cpp
+++ b/source/UI/apppopups.cpp
@@ -193,6 +193,9 @@ namespace Popups{
 					setcolor[3] = color.w;
 					configini->setSubFontColor(setcolor);
 					libmpv->setSubFontColor(configini->getSubFontColorHex(true));
+					printf("hey, check this: \n");
+					printf(configini->getSubFontColorHex(true).c_str());
+					printf("\n");
 					item.popupstate = POPUP_STATE_NONE;
 				}
 				ImGui::SameLine();

--- a/source/config.cpp
+++ b/source/config.cpp
@@ -485,19 +485,15 @@ void Config::saveSettings(){
 	ini->Delete("Main", "subfontsize");
 	ini->SetLongValue("Main", "subfontsize", subfontsize, NULL, false);
 	
+	//Fix Save color.
 	ini->Delete("Main", "subfontcolor");
-	char subfontcstr[32];
-	sprintf(subfontcstr,"#%02X%02X%02X",(unsigned int)subfontcolor[0]*255,(unsigned int)subfontcolor[1]*255,(unsigned int)subfontcolor[2]*255);
-	ini->SetValue("Main", "subfontcolor", subfontcstr);
+	ini->SetValue("Main", "subfontcolor", getSubFontColorHex(true).c_str());
 	
 	//bordercolor
 	ini->Delete("Main", "subbordercolor");
-	char subfontcstr2[32];
-	sprintf(subfontcstr2,"#%02X%02X%02X",(unsigned int)subbordercolor[0]*255,(unsigned int)subbordercolor[1]*255,(unsigned int)subbordercolor[2]*255);
-	ini->SetValue("Main", "subbordercolor", subfontcstr2);
-	
+	ini->SetValue("Main", "subbordercolor", getSubBorderColorHex(true).c_str());
 	//endbordercolor
-
+    //end Fix Save Color
 	std::vector<std::string> deintopts = {"no","yes","auto"};
 	ini->Delete("Main", "deinterlace");
 	ini->SetValue("Main", "deinterlace", deintopts[deint].c_str());


### PR DESCRIPTION
The color of the subtitle is not saved, when you change the color with the picker, and then go to settings and press "save" the next time you open it you will have a completely black subtitle.

This fixes the bug, which was even in 0.6.0